### PR TITLE
gitignore stata outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@ model.log
 __pycache__
 .python-version
 .idea
+analysis/*
+!*.do
+!*.ado
+!*.hlp
+!*.py
+!*.sthlp


### PR DESCRIPTION
This is to stop stata outputs generated from dummy data being accidentally committed to the repo.