### PR TITLE
Minor fixes

### DIFF
--- a/analysis/04_an_descriptive_table_asthma.do
+++ b/analysis/04_an_descriptive_table_asthma.do
@@ -134,52 +134,52 @@ syntax, variable(varname)
 	
 	qui summarize `variable', d
 	file write tablecontent ("Median (IQR)") _tab 
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _n
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _n
 	
 	qui summarize `variable', d
 	file write tablecontent ("Mean (SD)") _tab 
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(mean)) (" (") (r(sd))  (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(mean)) (" (") (r(sd))  (")") _n
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _n
 	
 	
 	qui summarize `variable', d
 	file write tablecontent ("Min, Max") _tab 
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _n
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _n
 	
 end
 

--- a/analysis/04_an_descriptive_table_copd.do
+++ b/analysis/04_an_descriptive_table_copd.do
@@ -128,45 +128,45 @@ syntax, variable(varname)
 	
 	qui summarize `variable', d
 	file write tablecontent ("Median (IQR)") _tab 
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _n
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _n
 	
 	qui summarize `variable', d
 	file write tablecontent ("Mean (SD)") _tab 
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(mean)) (" (") (r(sd))  (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(mean)) (" (") (r(sd))  (")") _n
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _n
 	
 	qui summarize `variable', d
 	file write tablecontent ("Min, Max") _tab 
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _n
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _n
 	
 end 
 

--- a/analysis/04_an_descriptive_table_copd.do
+++ b/analysis/04_an_descriptive_table_copd.do
@@ -148,9 +148,6 @@ syntax, variable(varname)
 
 	qui summarize `variable' if exposure == 1, d
 	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
-	
-	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
 	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _n

--- a/analysis/06_an_models_asthma.do
+++ b/analysis/06_an_models_asthma.do
@@ -127,7 +127,7 @@ file write tablecontent ("`lab2'") _tab
 
 	count if exposure == 2 & $outcome == 1
 	local event = r(N)
-	summarize total_follow_up if exposure == 1
+	summarize total_follow_up if exposure == 2
 	local person_week = r(mean)/7
 	local rate = 1000*(`event'/`person_week')
 	file write tablecontent (`event') _tab %10.0f (`person_week') _tab %3.2f (`rate') _tab

--- a/analysis/07_an_models_interact_asthma.do
+++ b/analysis/07_an_models_interact_asthma.do
@@ -161,7 +161,7 @@ syntax, variable(varname) min(real) max(real)
 
 			count if exposure == 2 & `variable' == `varlevel' & $outcome == 1
 			local event = r(N)
-			summarize total_follow_up if exposure == 1 & `variable' == `varlevel'
+			summarize total_follow_up if exposure == 2 & `variable' == `varlevel'
 			local person_week = r(mean)/7
 			local rate = 1000*(`event'/`person_week')
 			

--- a/analysis/07_an_models_interact_copd.do
+++ b/analysis/07_an_models_interact_copd.do
@@ -119,7 +119,7 @@ syntax, variable(varname) min(real) max(real)
 		
 		file write tablecontent ("`lab0'") _tab
 
-			count if exposure == 0 & $outcome == 1`variable' == `varlevel' & $outcome == 1
+			count if exposure == 0 & $outcome == 1 & `variable' == `varlevel' 
 			local event = r(N)
 			bysort exposure `variable': egen total_follow_up = total(_t)
 			summarize total_follow_up if exposure == 0 & `variable' == `varlevel'

--- a/analysis/07_an_models_interact_copd.do
+++ b/analysis/07_an_models_interact_copd.do
@@ -119,7 +119,7 @@ syntax, variable(varname) min(real) max(real)
 		
 		file write tablecontent ("`lab0'") _tab
 
-			count if exposure == 0  & `variable' == `varlevel' & $outcome == 1
+			count if exposure == 0 & $outcome == 1`variable' == `varlevel' & $outcome == 1
 			local event = r(N)
 			bysort exposure `variable': egen total_follow_up = total(_t)
 			summarize total_follow_up if exposure == 0 & `variable' == `varlevel'
@@ -133,9 +133,9 @@ syntax, variable(varname) min(real) max(real)
 
 		file write tablecontent ("`lab1'") _tab  
 
-			count if exposure == 1 & $outcome == 1
+			count if exposure == 1 & $outcome == 1 & `variable' == `varlevel'
 			local event = r(N)
-			summarize total_follow_up if exposure == 1
+			summarize total_follow_up if exposure == 1 & `variable' == `varlevel'
 			local person_week = r(mean)/7
 			local rate = 1000*(`event'/`person_week')
 			file write tablecontent (`event') _tab %10.0f (`person_week') _tab %3.2f (`rate') _tab

--- a/analysis/10_an_models_ethnicity_asthma.do
+++ b/analysis/10_an_models_ethnicity_asthma.do
@@ -126,7 +126,7 @@ file write tablecontent ("`lab2'") _tab
 
 	count if exposure == 2 & $outcome == 1
 	local event = r(N)
-	summarize total_follow_up if exposure == 1
+	summarize total_follow_up if exposure == 2
 	local person_week = r(mean)/7
 	local rate = 1000*(`event'/`person_week')
 	file write tablecontent (`event') _tab %10.0f (`person_week') _tab %3.2f (`rate') _tab

--- a/analysis/S1-04_an_descriptive_table_copd.do
+++ b/analysis/S1-04_an_descriptive_table_copd.do
@@ -135,51 +135,51 @@ syntax, variable(varname)
 	
 	qui summarize `variable', d
 	file write tablecontent ("Median (IQR)") _tab 
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _tab
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(p50)) (" (") (r(p25)) ("-") (r(p75)) (")") _n
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _n
 	
 	qui summarize `variable', d
 	file write tablecontent ("Mean (SD)") _tab 
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(mean)) (" (") (r(sd)) (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(mean)) (" (") (r(sd))  (")") _tab
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(mean)) (" (") (r(sd))  (")") _n
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _n
 	
 	qui summarize `variable', d
 	file write tablecontent ("Min, Max") _tab 
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 							
 	qui summarize `variable' if exposure == 0, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 
 	qui summarize `variable' if exposure == 1, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 	
 	qui summarize `variable' if exposure == 2, d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _tab
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
 
 	qui summarize `variable' if exposure >= ., d
-	file write tablecontent (r(min)) (", ") (r(max)) ("") _n
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _n
 	
 end
 

--- a/analysis/S1-06_an_models_copd.do
+++ b/analysis/S1-06_an_models_copd.do
@@ -122,7 +122,7 @@ file write tablecontent ("`lab2'") _tab
 
 	count if exposure == 2 & $outcome == 1
 	local event = r(N)
-	summarize total_follow_up if exposure == 1
+	summarize total_follow_up if exposure == 2
 	local person_week = r(mean)/7
 	local rate = 1000*(`event'/`person_week')
 	file write tablecontent (`event') _tab %10.0f (`person_week') _tab %3.2f (`rate') _tab


### PR DESCRIPTION
This contains two fixes: 

- Incorrectly calculated denominator PYFU when exposure level increased from 1 to 2 
- Introduce rounding of continous vars to 2dps in Table 1s throughout 

The following files will need to be re-run: 

- All programs beginning -04. 
- All programs beginning -06. 
- All programs beginning -07. 
- All programs beginnig -10

08 is a dependency on 06, but the only changes in the models are to do with the rates (not the models themselves). Let me know if you think we should just re-run all of the analyses (ie all programs >04), which shouldn't take too long.... 