### PR TITLE
add tables

### DIFF
--- a/analysis/12_summarize_FU_asthma.do
+++ b/analysis/12_summarize_FU_asthma.do
@@ -1,0 +1,109 @@
+/*==============================================================================
+DO FILE NAME:			12_summarize FU
+PROJECT:				ICS in COVID-19 
+AUTHORS:				A Schultze
+						adapted from K Baskharan A Wong
+DATE: 					19th September 2020
+VERSION: 				Stata 16.1 
+DESCRIPTION OF FILE:	tabulate median (IQR), min max FU time 
+						added due to RECORD-PE guidance
+DATASETS USED:			$tempdir\analysis_dataset_STSET_$outcome.dta
+DATASETS CREATED: 		None
+OTHER OUTPUT: 			Results in txt format, output folder
+						Log file: $logdir\12_summarize_FU_asthma 
+						
+==============================================================================*/
+
+* Open a log file
+capture log close
+log using $logdir\12_summarize_FU_asthma, replace t
+
+* Open Stata dataset
+use $tempdir\analysis_dataset_STSET_$outcome, clear
+
+* Output summary of FU time into a table, by treatment group 
+
+cap prog drop summarizevariable 
+prog define summarizevariable
+syntax, variable(varname) 
+
+	local lab: variable label `variable'
+	file write tablecontent ("`lab'") _n 
+	
+	qui summarize `variable', d
+	file write tablecontent ("Median (IQR)") _tab 
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+							
+	qui summarize `variable' if exposure == 0, d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure == 1, d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+	
+	qui summarize `variable' if exposure == 2, d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure >= ., d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _n
+	
+	qui summarize `variable', d
+	file write tablecontent ("Mean (SD)") _tab 
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+							
+	qui summarize `variable' if exposure == 0, d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure == 1, d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+	
+	qui summarize `variable' if exposure == 2, d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure >= ., d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _n
+	
+	
+	qui summarize `variable', d
+	file write tablecontent ("Min, Max") _tab 
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+							
+	qui summarize `variable' if exposure == 0, d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+
+	qui summarize `variable' if exposure == 1, d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+	
+	qui summarize `variable' if exposure == 2, d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+
+	qui summarize `variable' if exposure >= ., d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _n
+	
+end
+
+*Set up output file
+cap file close tablecontent
+file open tablecontent using ./$outdir/tableSFU.txt, write text replace
+
+file write tablecontent ("Table S: Follow-up Time - $population") _n
+
+* Exposure labelled columns
+
+local lab0: label exposure 0
+local lab1: label exposure 1
+local lab2: label exposure 2
+local labu: label exposure .u
+
+
+file write tablecontent _tab ("Total")				  			  _tab ///
+							 ("`lab0'")			 			      _tab ///
+							 ("`lab1'")  						  _tab ///
+							 ("`lab2'")			  				  _tab ///
+							 ("`labu'")			  				  _n 
+							 
+summarizevariable, variable(_t)
+
+file close tablecontent
+
+* Close log file 
+log close

--- a/analysis/12_summarize_FU_copd.do
+++ b/analysis/12_summarize_FU_copd.do
@@ -1,0 +1,109 @@
+/*==============================================================================
+DO FILE NAME:			12_summarize FU
+PROJECT:				ICS in COVID-19 
+AUTHORS:				A Schultze
+						adapted from K Baskharan A Wong
+DATE: 					19th September 2020
+VERSION: 				Stata 16.1 
+DESCRIPTION OF FILE:	tabulate median (IQR), min max FU time 
+						added due to RECORD-PE guidance
+DATASETS USED:			$tempdir\analysis_dataset_STSET_$outcome.dta
+DATASETS CREATED: 		None
+OTHER OUTPUT: 			Results in txt format, output folder
+						Log file: $logdir\12_summarize_FU_copd
+						
+==============================================================================*/
+
+* Open a log file
+capture log close
+log using $logdir\12_summarize_FU_copd, replace t
+
+* Open Stata dataset
+use $tempdir\analysis_dataset_STSET_$outcome, clear
+
+* Output summary of FU time into a table, by treatment group 
+
+cap prog drop summarizevariable 
+prog define summarizevariable
+syntax, variable(varname) 
+
+	local lab: variable label `variable'
+	file write tablecontent ("`lab'") _n 
+	
+	qui summarize `variable', d
+	file write tablecontent ("Median (IQR)") _tab 
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+							
+	qui summarize `variable' if exposure == 0, d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure == 1, d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+	
+	qui summarize `variable' if exposure == 2, d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure >= ., d
+	file write tablecontent (round(r(p50)),0.01) (" (") (round(r(p25)),0.01) ("-") (round(r(p75)),0.01) (")") _n
+	
+	qui summarize `variable', d
+	file write tablecontent ("Mean (SD)") _tab 
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+							
+	qui summarize `variable' if exposure == 0, d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure == 1, d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+	
+	qui summarize `variable' if exposure == 2, d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _tab
+
+	qui summarize `variable' if exposure >= ., d
+	file write tablecontent (round(r(mean)),0.01) (" (") (round(r(sd)),0.01) (")") _n
+	
+	
+	qui summarize `variable', d
+	file write tablecontent ("Min, Max") _tab 
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+							
+	qui summarize `variable' if exposure == 0, d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+
+	qui summarize `variable' if exposure == 1, d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+	
+	qui summarize `variable' if exposure == 2, d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _tab
+
+	qui summarize `variable' if exposure >= ., d
+	file write tablecontent (round(r(min)),0.01) (", ") (round(r(max)),0.01) ("") _n
+	
+end
+
+*Set up output file
+cap file close tablecontent
+file open tablecontent using ./$outdir/tableSFU.txt, write text replace
+
+file write tablecontent ("Table S: Follow-up Time - $population") _n
+
+* Exposure labelled columns
+
+local lab0: label exposure 0
+local lab1: label exposure 1
+local lab2: label exposure 2
+local labu: label exposure .u
+
+
+file write tablecontent _tab ("Total")				  			  _tab ///
+							 ("`lab0'")			 			      _tab ///
+							 ("`lab1'")  						  _tab ///
+							 ("`lab2'")			  				  _tab ///
+							 ("`labu'")			  				  _n 
+							 
+summarizevariable, variable(_t)
+
+file close tablecontent
+
+* Close log file 
+log close

--- a/analysis/model.do
+++ b/analysis/model.do
@@ -61,6 +61,7 @@ do "08_an_model_checks_copd.do"
 do "09_an_model_explore_copd.do"
 do "10_an_models_ethnicity_copd.do"
 do "11_an_stand_surv_copd.do"
+do "12_summarize_FU_copd.do"
 
 * Post peer review requested different adjustments
 do "Extra_06_an_models_copd.do" 
@@ -124,6 +125,7 @@ do "08_an_model_checks_asthma.do"
 do "09_an_model_explore_asthma.do"
 do "10_an_models_ethnicity_asthma.do"
 do "11_an_stand_surv_asthma.do"
+do "12_summarize_FU_asthma.do"
 
 * Post peer review requested different adjustments
 do "Extra_06_an_models_asthma.do" 


### PR DESCRIPTION
This PR adds tables which summarize FU formally, rather than just having this in log files, for transparency. 
These will be included in the appendix so that it's easy to see where these summary statistics are drawn from. 

They were added at a late stage to the paper, as a summary of the FU time is a recommendation in the RECORD-PE guidelines, but, arguably it is less important in this setting where the FU time is very short and the population so large that drop-out due to death will have a negligble impact. 